### PR TITLE
feat: Add page and API for creating students

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import RootLayout from "./components/layout/RootLayout";
 import UserPage from "./features/user/UserPage";
 import ReportPage from "./features/report/ReportPage";
 import SearchAndReportPage from "./features/report/SearchAndReportPage";
+import AddStudentPage from "./features/student/AddStudentPage";
 import AddJson from "./features/dev/AddJson";
 import VerifyEmailPage from "./features/auth/VerifyEmailPage";
 import HealthCheckPage from "./features/healthcheck/HealthCheckPage";
@@ -34,6 +35,7 @@ const App = () => {
               <Route path="reports" element={<ReportPage />} />
               <Route path="setting" element={<SettingPage />} />
               <Route path="users" element={<UserPage />} />
+              <Route path="admin/add-student" element={<AddStudentPage />} />
               <Route path="add/json" element={<AddJson />} />
             </Route>
             

--- a/client/src/components/AdminMenu.jsx
+++ b/client/src/components/AdminMenu.jsx
@@ -5,6 +5,7 @@ import {
   FileTextOutlined,
   SettingOutlined,
   DashboardOutlined,
+  UserAddOutlined,
 } from "@ant-design/icons";
 import { useNavigate } from "react-router-dom";
 
@@ -31,6 +32,10 @@ export default function AdminMenu({ profile }) {
 
         {profile && adminRoles.includes(profile.role) && (
           <>
+            <Menu.Item key="/admin/add-student" icon={<UserAddOutlined />}>
+              เพิ่มนักเรียน
+            </Menu.Item>
+
             <Menu.Item key="/users" icon={<UserOutlined />}>
               จัดการผู้ใช้งาน
             </Menu.Item>

--- a/client/src/features/student/AddStudentPage.jsx
+++ b/client/src/features/student/AddStudentPage.jsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { Form, Input, Button, Card, Row, Col, message, Select } from 'antd';
+import api from '../../lib/api';
+
+const { Option } = Select;
+
+const AddStudentPage = () => {
+  const [form] = Form.useForm();
+  const [loading, setLoading] = useState(false);
+
+  const onFinish = async (values) => {
+    setLoading(true);
+    try {
+      // Convert sid and classroom to numbers
+      const payload = {
+        ...values,
+        sid: parseInt(values.sid, 10),
+        classroom: parseInt(values.classroom, 10),
+        status: 'active', // Default status
+      };
+
+      const response = await api.post('/admin/students', payload);
+      message.success('Student added successfully!');
+      form.resetFields();
+    } catch (err) {
+      const errorMessage = err.response?.data?.message || 'Failed to add student. Please try again.';
+      message.error(errorMessage);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card title="Add New Student">
+      <Form form={form} layout="vertical" onFinish={onFinish}>
+        <Row gutter={16}>
+          <Col span={8}>
+            <Form.Item
+              name="sid"
+              label="Student ID (SID)"
+              rules={[{ required: true, message: 'Please input the student ID!' }]}
+            >
+              <Input type="number" placeholder="e.g. 12345" />
+            </Form.Item>
+          </Col>
+          <Col span={8}>
+            <Form.Item
+              name="prefix"
+              label="Prefix"
+              rules={[{ required: true, message: 'Please select a prefix!' }]}
+            >
+              <Select placeholder="Select a prefix">
+                <Option value="เด็กชาย">เด็กชาย</Option>
+                <Option value="เด็กหญิง">เด็กหญิง</Option>
+                <Option value="นาย">นาย</Option>
+                <Option value="นางสาว">นางสาว</Option>
+              </Select>
+            </Form.Item>
+          </Col>
+          <Col span={8}>
+             <Form.Item
+              name="nickname"
+              label="Nickname"
+            >
+              <Input placeholder="e.g. Somchai" />
+            </Form.Item>
+          </Col>
+        </Row>
+        <Row gutter={16}>
+          <Col span={12}>
+            <Form.Item
+              name="firstName"
+              label="First Name"
+              rules={[{ required: true, message: 'Please input the first name!' }]}
+            >
+              <Input placeholder="e.g. John" />
+            </Form.Item>
+          </Col>
+          <Col span={12}>
+            <Form.Item
+              name="lastName"
+              label="Last Name"
+              rules={[{ required: true, message: 'Please input the last name!' }]}
+            >
+              <Input placeholder="e.g. Doe" />
+            </Form.Item>
+          </Col>
+        </Row>
+        <Row gutter={16}>
+           <Col span={12}>
+            <Form.Item
+              name="email"
+              label="Email"
+              rules={[{ type: 'email', message: 'The input is not valid E-mail!' }]}
+            >
+              <Input placeholder="e.g. john.doe@example.com" />
+            </Form.Item>
+          </Col>
+          <Col span={12}>
+            <Form.Item
+              name="phoneNumber"
+              label="Phone Number"
+            >
+              <Input placeholder="e.g. 0812345678" />
+            </Form.Item>
+          </Col>
+        </Row>
+        <Row gutter={16}>
+          <Col span={12}>
+            <Form.Item
+              name="grade"
+              label="Grade"
+              rules={[{ required: true, message: 'Please input the grade!' }]}
+            >
+              <Input placeholder="e.g. ม.6" />
+            </Form.Item>
+          </Col>
+          <Col span={12}>
+            <Form.Item
+              name="classroom"
+              label="Classroom"
+              rules={[{ required: true, message: 'Please input the classroom!' }]}
+            >
+              <Input type="number" placeholder="e.g. 3" />
+            </Form.Item>
+          </Col>
+        </Row>
+        <Form.Item>
+          <Button type="primary" htmlType="submit" loading={loading}>
+            Add Student
+          </Button>
+        </Form.Item>
+      </Form>
+    </Card>
+  );
+};
+
+export default AddStudentPage;

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -5,6 +5,7 @@ const reportRoutes = require('../features/report/report.routes');
 const userRoutes = require('../features/user/user.routes');
 const settingRoutes = require('../features/setting/setting.routes');
 const dashboardRoutes = require('../features/dashboard/dashboard.routes');
+const studentRoutes = require('../features/student/student.routes');
 
 const router = express.Router();
 
@@ -15,5 +16,6 @@ router.use('/student/reports', reportRoutes);
 router.use('/admin/users', userRoutes);
 router.use('/admin/settings', settingRoutes);
 router.use('/admin/dashboard', dashboardRoutes);
+router.use('/admin/students', studentRoutes);
 
 module.exports = router; 

--- a/src/features/student/student.controller.js
+++ b/src/features/student/student.controller.js
@@ -1,0 +1,28 @@
+const StudentService = require('./student.service');
+
+class StudentController {
+  constructor(studentService) {
+    this.studentService = studentService;
+  }
+
+  createStudent = async (req, res, next) => {
+    try {
+      const student = await this.studentService.createStudent(req.body);
+      res.status(201).json({
+        isError: false,
+        message: 'Student created successfully',
+        result: student,
+      });
+    } catch (error) {
+      if (error.code === 'P2002' && error.meta?.target?.includes('sid')) {
+        return res.status(409).json({ isError: true, message: 'Student with this SID already exists.' });
+      }
+      if (error.code === 'P2002' && error.meta?.target?.includes('email')) {
+        return res.status(409).json({ isError: true, message: 'Student with this email already exists.' });
+      }
+      next(error);
+    }
+  };
+}
+
+module.exports = new StudentController(StudentService);

--- a/src/features/student/student.repository.js
+++ b/src/features/student/student.repository.js
@@ -1,0 +1,11 @@
+const prisma = require('../../core/prisma');
+
+class StudentRepository {
+  async createStudent(studentData) {
+    return prisma.student.create({
+      data: studentData,
+    });
+  }
+}
+
+module.exports = new StudentRepository();

--- a/src/features/student/student.routes.js
+++ b/src/features/student/student.routes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const studentController = require('./student.controller');
+const { protect, admin } = require('../../core/middleware/auth');
+
+// @route   POST /api/v1/admin/students
+// @desc    Create a new student
+// @access  Private/Admin
+router.post('/', protect, admin, studentController.createStudent);
+
+module.exports = router;

--- a/src/features/student/student.service.js
+++ b/src/features/student/student.service.js
@@ -1,0 +1,10 @@
+const studentRepository = require('./student.repository');
+
+class StudentService {
+  async createStudent(studentData) {
+    // In the future, you can add business logic here, like validation, etc.
+    return studentRepository.createStudent(studentData);
+  }
+}
+
+module.exports = new StudentService();


### PR DESCRIPTION
This commit introduces a new feature that allows administrators to add new students to the system through a dedicated user interface.

A new API endpoint `POST /api/v1/admin/students` has been created to handle the creation of new student records. The endpoint is protected and requires admin privileges.

A new page has been added to the frontend at `/admin/add-student`, containing a form for submitting new student information.

The main navigation menu for administrators has been updated to include a link to the new "Add Student" page.