### PR TITLE
feat: Add CI pipeline for building Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      image_name_lower: ${{ steps.prep.outputs.image_name_lower }}
+    steps:
+      - name: Prepare image name
+        id: prep
+        run: echo "image_name_lower=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+  build-backend:
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image for backend
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ needs.prepare.outputs.image_name_lower }}-backend:${{ github.sha }}
+
+  build-frontend:
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image for frontend
+        uses: docker/build-push-action@v5
+        with:
+          context: ./client
+          file: ./client/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ needs.prepare.outputs.image_name_lower }}-frontend:${{ github.sha }}


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automate the building and pushing of Docker images for the frontend and backend services.

The workflow (`.github/workflows/ci.yml`) is triggered on every push to the `main` branch and consists of three jobs:

- `prepare`: Calculates a lowercase version of the repository name to be used in image tags.
- `build-backend`: Builds the backend Docker image and pushes it to the GitHub Container Registry (GHCR) with a tag based on the commit SHA.
- `build-frontend`: Builds the frontend Docker image and pushes it to GHCR with a tag based on the commit SHA.

This CI pipeline streamlines the deployment process by ensuring that a container image is automatically built and stored for every change pushed to the main branch.