### PR TITLE
fix: Add openssl to Dockerfile for Prisma

### DIFF
--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -10,6 +10,9 @@ RUN npm run build
 FROM node:18-alpine
 WORKDIR /app
 
+# Install OpenSSL, a dependency for Prisma on Alpine
+RUN apk add --no-cache openssl
+
 # Copy backend dependencies and install them
 COPY package*.json ./
 # We need to install all dependencies, including dev, for prisma to work at runtime


### PR DESCRIPTION
This commit fixes a runtime error where Prisma was unable to connect to the database due to a missing OpenSSL library in the Alpine-based Docker image.

The error manifested as `Prisma failed to detect the libssl/openssl version` and `Could not parse schema engine response`.

The `openssl` package is now explicitly installed in the `Dockerfile.unified` to ensure that Prisma can establish a secure connection to the database. This resolves the container startup failure during deployment.