### PR TITLE
fix: Correct build order in Dockerfile for prisma generate

### DIFF
--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -13,13 +13,13 @@ WORKDIR /app
 # Install OpenSSL, a dependency for Prisma on Alpine
 RUN apk add --no-cache openssl
 
-# Copy backend dependencies and install them
+# Copy package files and prisma schema
 COPY package*.json ./
-# We need to install all dependencies, including dev, for prisma to work at runtime
-RUN npm install
-
-# Copy prisma schema and migrations
 COPY prisma ./prisma/
+
+# Install dependencies. This will also trigger `prisma generate`
+# because the prisma schema is now available.
+RUN npm install
 
 # Copy the rest of the backend source code
 COPY src ./src


### PR DESCRIPTION
This commit fixes a runtime error where the `prisma:seed` script failed because the Prisma Client was not generated correctly.

The error `@prisma/client did not initialize yet` occurred because `npm install` (which triggers `prisma generate`) was running before the `prisma/schema.prisma` file was copied into the build context.

This has been resolved by reordering the commands in the `Dockerfile.unified` to ensure that the `prisma` directory is copied *before* `npm install` is executed. This allows `prisma generate` to run successfully, making the Prisma Client available to the seed script and the rest of the application.