### PR TITLE
fix: Add build verification to Dockerfile

### DIFF
--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -6,6 +6,12 @@ RUN npm install
 COPY client/ ./
 RUN npm run build
 
+# Verify that the build was successful and created the necessary files
+RUN if [ ! -d "dist" ] || [ ! -f "dist/index.html" ]; then \
+      echo "Vite build failed: 'dist' directory or 'dist/index.html' not found." >&2; \
+      exit 1; \
+    fi
+
 # Stage 2: Build the final image with the backend and the built client
 FROM node:18-alpine
 WORKDIR /app


### PR DESCRIPTION
This commit adds a verification step to the multi-stage Dockerfile to ensure that the frontend build (`npm run build`) completes successfully and creates the necessary output directory (`dist`).

This change is intended to diagnose a "white screen" issue that is likely caused by a silent failure in the frontend build process. By adding an explicit check for the build artifacts, the Docker build will now fail loudly if the frontend build does not produce the expected output, making the root cause visible in the CI/CD logs.